### PR TITLE
Add env_500 Documentation and Update Container Startup Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ This project integrates Isaac Sim, Isaac Lab, ROS2 (Humble), and Nav2 to facilit
 2.  Build the Docker image:
 
     ```bash
-    docker compose build
+    docker compose --profile env_320 build   # for version 3.2.0
     ```
 
 ### Option 2: Download Pre-built Container
 
+For quick start, we only support after env version 3.2.0
+
+```bash
 Available container versions (Isaac Sim 4.5.0):
 
 | Version | Isaac Lab Version | Description |
@@ -35,6 +38,13 @@ Available container versions (Isaac Sim 4.5.0):
 | 3.0.0   | 2.1.0            | Module docker |
 | 3.1.0   | 2.1.0            | Slim down container |
 | 3.2.0   | 2.1.0            | Add sudo user & ros2 package - pointcloud_to_laserscan|
+
+
+
+Available container versions (Isaac Sim 5.0.0):
+| Version | Isaac Lab Version | Description |
+|---------|-------------------|-------------|
+| 5.0.0   | 2.2.0            | Initial release |
 
 ## Version-Specific Setup Instructions
 

--- a/corporate_docker/README.md
+++ b/corporate_docker/README.md
@@ -95,31 +95,66 @@ corporate_docker/
 
 ## 🚀 Quick Start
 
+
 ### 1. Build the Image
 
+
+<!-- Build the image using the profile that matches the version you want (3.2.0 or 5.0.0). -->
 ```bash
 cd corporate_docker/docker
-docker compose build
+# Choose the build profile for the version you need
+docker compose --profile env_320 build   # build the 3.2.0 image
+# or
+docker compose --profile env_500 build   # build the 5.0.0 image
 ```
+
 
 ### 2. Start the Container (Development Mode)
 
+<!-- Start the container in the background. Use X11 forwarding if you need GUI access from the host. -->
 ```bash
-xhost +local:docker # For X11 forwarding (optional)
-docker compose up -d
+# Allow X11 connections from local docker (only if using host X11)
+xhost +local:docker
+
+# Start the chosen profile in detached mode
+docker compose --profile env_320 up -d --no-build    # start 3.2.0 containers
+# or
+docker compose --profile env_500 up -d --no-build    # start 5.0.0 containers
 ```
 
 ### 3. Enter the Container
-
+<!-- Use compose exec when you started with compose (recommended). If you started a standalone container, use docker exec. -->
 ```bash
-docker compose exec h1-ws bash
+# If you used docker compose
+docker compose exec env320 bash    # enter the env_320 service shell
+# or
+docker compose exec env500 bash    # enter the env_500 service shell
 
+# If you started a standalone container image
+docker exec -it isaac-workspace-3.2.0 bash
 ```
-or
+
+### 3. Stop and clean up
+
+<!-- Properly stop the services and remove containers when finished. -->
 ```bash
-docker exec -it isaac-workspace bash
+# Stop services started by compose
+docker compose --profile env_320 down    # stop and remove containers for env_320
+# or
+docker compose --profile env_500 down
 
+# If you started a single container with docker run, stop it by name or id
+docker stop isaac-workspace-3.2.0
+# or
+docker compose --profile env_320 stop
 ```
+
+### Notes
+
+- Profile names: `env_320` corresponds to the 3.2.0 environment, `env_500` to 5.0.0.
+- Use `docker compose ps` to check service status and `docker logs <service>` for logs.
+- If you need to bind a specific GPU to the container, start with `--gpus 'device=<index or uuid>'` or set `NVIDIA_VISIBLE_DEVICES` in compose.
+
 
 ## 🧪 Complete Test Workflow
 

--- a/corporate_docker/docker/Dockerfile
+++ b/corporate_docker/docker/Dockerfile
@@ -119,8 +119,8 @@ RUN mkdir -p /home/$USERNAME/.vnc \
 
 USER root
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0
-# ARG ISAAC_SIM_VERSION=5.0.0
+# ARG ISAAC_SIM_VERSION=4.5.0
+ARG ISAAC_SIM_VERSION=5.0.0
 # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
 ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script

--- a/corporate_docker/docker/compose.yaml
+++ b/corporate_docker/docker/compose.yaml
@@ -1,59 +1,6 @@
 name: ros2-h1-ws
-services:
-  # volume-instantiation:
-  #   # Ref: https://github.com/moby/moby/issues/47842#issuecomment-2249050939
-  #   image: ubuntu:22.04
-  #   container_name: ros2-h1-ws-volume-instantiation
-  #   command: bash -c "
-  #       echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
-  #       mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
-  #       mkdir -p /isaac-sim/{logs,data,documents} &&
-  #       mkdir -p /isaac-sim/standalone/cache/ov &&
-  #       mkdir -p /isaac-sim/standalone/{logs,data} &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
-  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
-  #       "
-  #   volumes:
-  #     - isaac-sim-cache:/isaac-sim
-  h1-ws:
-    # depends_on:
-    #   - volume-instantiation
-    build:
-      context: .
-      dockerfile: Dockerfile
-      # TODO: Specify the target platform to build the image, otherwise it will build for the host platform.
-      # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
-      # platforms:
-      #   - "linux/arm64"
-      args:
-        # TODO: Set the USER_UID
-        USER_UID: "${USER_UID:-1000}"
-        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
-        # CUDA_TOOLKIT_VERSION: ""
-        # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
-        # ISAAC_SIM_VERSION: "4.5.0"
-        # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
-        # ISAAC_LAB_VERSION: "2.1.0"
-        # TODO: Set Isaac ROS to "" if not using Isaac ROS
-        # ISAAC_ROS: "YES"
-      # cache_from:
-      #   - j3soon/ros2-h1-ws:buildcache-amd64
-      #   - j3soon/ros2-h1-ws:buildcache-arm64
-    image: newbieKD/isaac_sim_lab_ros2_nav2:3.1.0
-    container_name: isaac-workspace
-    stdin_open: true
-    tty: true
-    # TODO: Comment the line below if the workspace don't need to communicate through `/dev/*` devices.
-    privileged: true
-    command: /bin/bash
-    network_mode: host
-    working_dir: /home/ros2-essentials/h1_ws
+
+x-common: &common
     environment:
       # Set X11 server environment variable for existing display.
       - DISPLAY=$DISPLAY
@@ -197,3 +144,109 @@ services:
 #   isaac-sim-cache:
 #     name: ros2-isaac-sim-cache
 #     external: true
+
+# Add new service need change
+#  - ISAAC_SIM_VERSION 
+#  - ISAAC_LAB_VERSION
+#  - env_version
+#  - image
+#  - container_name
+#  - profiles
+#  - services name, ex env320, env500
+
+services:
+  # volume-instantiation:
+  #   # Ref: https://github.com/moby/moby/issues/47842#issuecomment-2249050939
+  #   image: ubuntu:22.04
+  #   container_name: ros2-h1-ws-volume-instantiation
+  #   command: bash -c "
+  #       echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
+  #       mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+  #       mkdir -p /isaac-sim/{logs,data,documents} &&
+  #       mkdir -p /isaac-sim/standalone/cache/ov &&
+  #       mkdir -p /isaac-sim/standalone/{logs,data} &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+  #       chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+  #       "
+  #   volumes:
+  #     - isaac-sim-cache:/isaac-sim
+  env320:
+    # depends_on:
+    #   - volume-instantiation
+    <<: *common
+    build:
+      context: .
+      dockerfile: Dockerfile
+      # TODO: Specify the target platform to build the image, otherwise it will build for the host platform.
+      # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
+      # platforms:
+      #   - "linux/arm64"
+      args:
+        # TODO: Set the USER_UID
+        USER_UID: "${USER_UID:-1000}"
+        ISAAC_SIM_VERSION: "4.5.0"
+        ISAAC_LAB_VERSION: "2.1.0"
+        env_version: "3.2.0"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
+        # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+        # ISAAC_SIM_VERSION: "4.5.0"
+        # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+        # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
+      # cache_from:
+      #   - j3soon/ros2-h1-ws:buildcache-amd64
+      #   - j3soon/ros2-h1-ws:buildcache-arm64
+    image: ghcr.io/newbiekd/isaac_ros2_nav2:3.2.0
+    container_name: isaac-workspace-3.2.0
+    stdin_open: true
+    tty: true
+    # TODO: Comment the line below if the workspace don't need to communicate through `/dev/*` devices.
+    privileged: true
+    command: /bin/bash
+    network_mode: host
+    working_dir: /home/ros2-essentials/h1_ws
+    
+    profiles: ["env_320"]
+    
+
+  env500:
+    # depends_on:
+    #   - volume-instantiation
+    <<: *common
+    build:
+      context: .
+      dockerfile: Dockerfile
+      # TODO: Specify the target platform to build the image, otherwise it will build for the host platform.
+      # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
+      # platforms:
+      #   - "linux/arm64"
+      args:
+        # TODO: Set the USER_UID
+        USER_UID: "${USER_UID:-1000}"
+        ISAAC_SIM_VERSION: "5.0.0"
+        ISAAC_LAB_VERSION: "2.2.0"
+        env_version: "5.0.0"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
+    image: ghcr.io/newbiekd/isaac_ros2_nav2:5.0.0
+    container_name: isaac-workspace-5.0.0
+    stdin_open: true
+    tty: true
+    # TODO: Comment the line below if the workspace don't need to communicate through `/dev/*` devices.
+    privileged: true
+    command: /bin/bash
+    network_mode: host
+    working_dir: /home/ros2-essentials/h1_ws
+    
+    profiles: ["env_500"]
+    


### PR DESCRIPTION
Summary
This update introduces documentation and configuration improvements for the new env_500 environment, which supports Isaac Sim 5.0.0 and Isaac Lab 2.2.0.
Changes
- README.md
- Added documentation for the env_500 environment
- Clarified compatibility with Isaac Sim 5.0.0 and Isaac Lab 2.2.0
- Container Startup Method
- Updated to use the profile mechanism for selecting which environment version to launch or build
- Improves flexibility and consistency when managing multiple environments
- corporate_docker/README.md
- Updated instructions for starting containers
- Added details on using profiles to switch between environments
Notes
- The new startup method currently supports only env_320 and env_500
- Other legacy environments remain usable but are not yet integrated into the profile mechanism
